### PR TITLE
JS/7 - Add icons for hp

### DIFF
--- a/src/InitiativeTracker/HP/HPRenderer.tsx
+++ b/src/InitiativeTracker/HP/HPRenderer.tsx
@@ -2,12 +2,18 @@ import React from "react";
 import type { ICharacter } from "../../Types/Character";
 import type { IColumnProps } from "../../Components/Table/Column.tsx/Column";
 import DefaultColumn from "../../Components/Table/Column.tsx/DefaultColumn";
+import { FaDroplet } from "react-icons/fa6";
+import { FaSkull } from "react-icons/fa";
 
 /**
  * HP renderer component
  * Displays the HP and max HP of a character
  */
 const HPRenderer: React.FC<IColumnProps<ICharacter>> = (props) => {
+	const hpPercentage =
+		props.data?.hp && props.data?.maxHp
+			? props.data?.hp / props.data?.maxHp
+			: 0;
 	return (
 		<div style={{ display: "flex", alignItems: "center" }}>
 			<DefaultColumn
@@ -22,6 +28,8 @@ const HPRenderer: React.FC<IColumnProps<ICharacter>> = (props) => {
 				value={props.data?.maxHp || 0}
 				style={{ width: "50px" }}
 			/>
+			{hpPercentage < 0.5 && hpPercentage > 0 && <FaDroplet color="darkred" />}
+			{hpPercentage <= 0 && <FaSkull />}
 		</div>
 	);
 };


### PR DESCRIPTION
- Show a blood drop for characters under 50% health
- Show a skull for characters with 0 health 

<img width="1099" height="490" alt="Screenshot 2025-08-26 at 11 14 02 PM" src="https://github.com/user-attachments/assets/10dc6e12-34bf-417e-a9a0-229bf9200d00" />
